### PR TITLE
Normalize external-noise amplitude, surface costs in logging/plots, and tweak PPO defaults

### DIFF
--- a/src/pendulum_sim/noise.py
+++ b/src/pendulum_sim/noise.py
@@ -13,9 +13,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import sys
 from typing import Optional
 
 import numpy as np
+
+# Ensure repository-level noise utilities are importable when package is run from src/.
+_NOISE_TOOLS_DIR = Path(__file__).resolve().parents[2] / "noise"
+if str(_NOISE_TOOLS_DIR) not in sys.path:
+    sys.path.append(str(_NOISE_TOOLS_DIR))
 
 from asd_tools import (
     asd_from_asd_statistics,
@@ -135,9 +141,20 @@ def generate_external_noise(
 
     duration    = n * dt
     sample_rate = 1.0 / dt
-    series = asd_to_timeseries(duration, sample_rate, freq, asd,
-                               seed=seed if seed is not None else 0)
+    series = asd_to_timeseries(duration, sample_rate, freq, asd, seed=seed if seed is not None else 0)
     series = np.asarray(series[:n], dtype=float)
+
+    # `asd_tools.asd_to_timeseries` returns the correct spectral shape but with a
+    # large amplitude scale factor from its FFT/window convention.  Renormalise
+    # to the physically expected RMS implied by the input ASD:
+    #   sigma_target^2 = ∫ ASD(f)^2 df
+    # This preserves the target frequency content while restoring displacement
+    # units to meters at micro-motion scale.
+    target_var = float(np.trapezoid(np.maximum(asd, 0.0) ** 2, freq))
+    target_std = float(np.sqrt(max(target_var, 0.0)))
+    current_std = float(np.std(series))
+    if current_std > 0 and target_std > 0:
+        series = series * (target_std / current_std)
 
     if config.external_remove_mean and series.size > 0:
         series = series - float(np.mean(series))

--- a/src/pendulum_sim/rl_callbacks.py
+++ b/src/pendulum_sim/rl_callbacks.py
@@ -32,7 +32,9 @@ class ProgressLogger(BaseCallback):
         """Initialize reward-tracking buffers."""
         super().__init__(verbose)
         self.first_rew = None
+        self.first_cost = None
         self.reward_history = []
+        self.cost_history = []
         self.steps_history = []
 
     def _on_step(self) -> bool:
@@ -44,13 +46,15 @@ class ProgressLogger(BaseCallback):
     def _on_rollout_end(self) -> None:
         """Append per-rollout reward and timestep history."""
         if len(self.model.ep_info_buffer) > 0:
-            self.reward_history.append(np.mean([ep["r"] for ep in self.model.ep_info_buffer]))
+            mean_rew = float(np.mean([ep["r"] for ep in self.model.ep_info_buffer]))
+            self.reward_history.append(mean_rew)
+            self.cost_history.append(-mean_rew)
             self.steps_history.append(self.num_timesteps)
 
     def _on_training_end(self) -> None:
         """Print concise before/after reward diagnostics when training ends."""
         print("\n" + "=" * 32)
-        print(" AI PERFORMANCE (reward should increase toward 0)")
+        print(" AI PERFORMANCE (cost should decay toward 0)")
         print("=" * 32)
         if len(self.model.ep_info_buffer) > 0:
             final_rew = np.mean([ep["r"] for ep in self.model.ep_info_buffer])
@@ -60,6 +64,10 @@ class ProgressLogger(BaseCallback):
                 print(f"Initial Reward: {self.first_rew:.4f}")
                 print(f"Final Reward:   {final_rew:.4f}")
                 print(f"Improvement:    {improvement:.1f}%")
+                self.first_cost = -float(self.first_rew)
+                final_cost = -float(final_rew)
+                print(f"Initial Cost:   {self.first_cost:.4f}")
+                print(f"Final Cost:     {final_cost:.4f}")
             else:
                 print(f"Final Reward: {final_rew:.4f}")
         print("=" * 32)

--- a/src/pendulum_sim/rl_config.py
+++ b/src/pendulum_sim/rl_config.py
@@ -46,8 +46,9 @@ PPO_N_STEPS = int(os.getenv("PPO_N_STEPS", "1024"))
 PPO_LEARNING_RATE = float(os.getenv("PPO_LEARNING_RATE", "1e-4"))
 PPO_GAMMA = float(os.getenv("PPO_GAMMA", "0.999"))
 PPO_GAE_LAMBDA = float(os.getenv("PPO_GAE_LAMBDA", "0.98"))
-PPO_ENT_COEF = float(os.getenv("PPO_ENT_COEF", "0.0"))
-PPO_LOG_STD_INIT = float(os.getenv("PPO_LOG_STD_INIT", "-5.0"))
+# Keep non-zero exploration so PPO does not collapse to near-zero force policy.
+PPO_ENT_COEF = float(os.getenv("PPO_ENT_COEF", "0.001"))
+PPO_LOG_STD_INIT = float(os.getenv("PPO_LOG_STD_INIT", "-2.0"))
 
 # ---- retained run knobs ----
 NOISE_FREE_EP_PROB = REWARD.noise_free_ep_prob

--- a/src/pendulum_sim/rl_core.py
+++ b/src/pendulum_sim/rl_core.py
@@ -164,22 +164,26 @@ def main() -> None:
         )
         wandb_run.finish()
 
-    maybe_refresh_docs()
-
     # ---------------------------------------------------------------------
     # 5) Plot outputs (time-domain, ASD, bars, regulation, learning curve).
     # ---------------------------------------------------------------------
     fig1, axes = plt.subplots(2, 1, figsize=(11, 7), sharex=True)
     fig1.suptitle(f"LIGO Double Pendulum — RL / LQR / Cascade (seed={eval_seed})", fontsize=13)
-    axes[0].plot(t_p, x2_p * 1e3, color="gray", lw=1.2, label="Passive")
-    axes[0].plot(t_r, x2_r * 1e3, color="steelblue", lw=1.2, label="RL-only")
-    axes[0].plot(t_l, x2_l * 1e3, color="seagreen", lw=1.2, label="LQR-only")
-    axes[0].plot(t_c, x2_c * 1e3, color="purple", lw=1.2, label=f"Cascade (LQR + {CASCADE_ALPHA:.2f}*RL)")
-    axes[0].set_ylabel("x₂ (mm)")
+    # Demean for visual comparability; scalar metrics still use raw signals.
+    x2_p_mm = (x2_p - np.mean(x2_p)) * 1e3
+    x2_r_mm = (x2_r - np.mean(x2_r)) * 1e3
+    x2_l_mm = (x2_l - np.mean(x2_l)) * 1e3
+    x2_c_mm = (x2_c - np.mean(x2_c)) * 1e3
+    axes[0].plot(t_p, x2_p_mm, color="gray", lw=1.2, label="Passive")
+    axes[0].plot(t_r, x2_r_mm, color="steelblue", lw=1.2, label="RL-only")
+    axes[0].plot(t_l, x2_l_mm, color="seagreen", lw=1.2, label="LQR-only")
+    axes[0].plot(t_c, x2_c_mm, color="purple", lw=1.2, label=f"Cascade (LQR + {CASCADE_ALPHA:.2f}*RL)")
+    axes[0].set_ylabel("x₂ (mm, demeaned)")
     axes[0].legend()
     axes[0].grid(alpha=0.4)
 
-    f_range = max(np.abs(f_r).max(), np.abs(f_l).max(), np.abs(f_c).max(), 0.01)
+    # Avoid flattening near-zero controllers by forcing a much smaller floor.
+    f_range = max(np.abs(f_r).max(), np.abs(f_l).max(), np.abs(f_c).max(), 5e-4)
     axes[1].plot(t_r, f_r, color="crimson", lw=1.0, label="RL force")
     axes[1].plot(t_l, f_l, color="darkgreen", lw=1.0, label="LQR force")
     axes[1].plot(t_c, f_c, color="indigo", lw=1.0, label="Cascade force")
@@ -254,15 +258,18 @@ def main() -> None:
 
     if len(logger.reward_history) > 1:
         fig3, ax3 = plt.subplots(figsize=(10, 4))
-        ax3.plot(logger.steps_history, logger.reward_history, color="steelblue", lw=1.2, alpha=0.6)
-        if len(logger.reward_history) >= 5:
-            smoothed = np.convolve(logger.reward_history, np.ones(5) / 5, mode="valid")
+        ax3.plot(logger.steps_history, logger.cost_history, color="steelblue", lw=1.2, alpha=0.6)
+        if len(logger.cost_history) >= 5:
+            smoothed = np.convolve(logger.cost_history, np.ones(5) / 5, mode="valid")
             ax3.plot(logger.steps_history[4:], smoothed, color="crimson", lw=2.0)
         ax3.set_xlabel("Training steps")
-        ax3.set_ylabel("Mean episode reward")
+        ax3.set_ylabel("Mean episode cost (-reward)")
         ax3.grid(alpha=0.4)
         plt.tight_layout()
         fig3.savefig(PLOTS_DIR / "rl_learning_curve.png", dpi=150)
+
+    # Refresh README/docs only after plots/metrics are fully written.
+    maybe_refresh_docs()
 
     print(f"Saved plots: {file1}, {file2}, {PLOTS_DIR / 'rl_lqr_cascade_comparison.png'}")
     plt.show()

--- a/src/pendulum_sim/rl_env.py
+++ b/src/pendulum_sim/rl_env.py
@@ -161,9 +161,21 @@ class LIGOPendulumEnv(gym.Env):
 
         options = options or {}
         self.noise_enabled = bool(options.get("noise", True))
-        self.state = np.array(
-            options.get("initial_state", np.zeros(4, dtype=np.float32)), dtype=np.float32
-        )
+        if "initial_state" in options:
+            init_state = np.array(options["initial_state"], dtype=np.float32)
+        else:
+            # Train around (not only at) equilibrium so no-noise regulation
+            # rollouts are in-distribution for the learned policy.
+            init_state = np.array(
+                [
+                    self.np_random.uniform(-0.02, 0.02),
+                    self.np_random.uniform(-0.02, 0.02),
+                    self.np_random.uniform(-0.01, 0.01),
+                    self.np_random.uniform(-0.01, 0.01),
+                ],
+                dtype=np.float32,
+            )
+        self.state = init_state
         self.current_step = 0
         self.x2_hist = []
         self.force_hist = []

--- a/src/pendulum_sim/rl_reporting.py
+++ b/src/pendulum_sim/rl_reporting.py
@@ -32,6 +32,8 @@ def write_rl_summary(eval_seed, rms_p, rms_r, improvement_x, reward_hist, run_re
         "improvement_x": float(improvement_x),
         "reward_initial": float(reward_hist[0]) if reward_hist else None,
         "reward_final": float(reward_hist[-1]) if reward_hist else None,
+        "cost_initial": float(-reward_hist[0]) if reward_hist else None,
+        "cost_final": float(-reward_hist[-1]) if reward_hist else None,
         "run_reg_test": bool(run_reg_test),
         "reg_final_abs_x2_mm": None if reg_final_mm is None else float(reg_final_mm),
         "noise_model": NOISE_MODEL,

--- a/tools/tools_refresh_readme.py
+++ b/tools/tools_refresh_readme.py
@@ -30,8 +30,8 @@ def build_block():
             f"- RL RMS x2: `{rl.get('rms_rl_mm', 0):.3f} mm`",
             f"- Improvement factor (passive/RL): `{rl.get('improvement_x', 0):.2f}x`",
         ]
-        if rl.get("reward_initial") is not None and rl.get("reward_final") is not None:
-            lines += [f"- Reward initial/final: `{rl['reward_initial']:.4f} -> {rl['reward_final']:.4f}`"]
+        if rl.get("cost_initial") is not None and rl.get("cost_final") is not None:
+            lines += [f"- Cost initial/final (-reward): `{rl['cost_initial']:.4f} -> {rl['cost_final']:.4f}`"]
         if rl.get("run_reg_test") and rl.get("reg_final_abs_x2_mm") is not None:
             lines += [f"- No-noise regulation final |x2|: `{rl['reg_final_abs_x2_mm']:.3f} mm`"]
         lines += [


### PR DESCRIPTION
### Motivation
- Ensure externally-synthesised noise has the physically expected RMS consistent with the input ASD so metrics are meaningful.
- Surface cost (negative reward) in logs, metrics, and plots to improve interpretability where lower is better.
- Make PPO exploration non-zero by default to avoid collapse to near-zero-force policies and improve training stability.

### Description
- `src/pendulum_sim/noise.py`: add repository import-path hack for `noise` tools and renormalise `asd_to_timeseries` output to match target ASD RMS, preserving spectral shape and physical displacement units.
- `src/pendulum_sim/rl_callbacks.py`: track `cost_history` (=-reward), record `first_cost`, and print cost summaries alongside reward diagnostics.
- `src/pendulum_sim/rl_config.py`: change default PPO hyperparameters to `PPO_ENT_COEF=0.001` and `PPO_LOG_STD_INIT=-2.0` to keep non-zero exploration.
- `src/pendulum_sim/rl_core.py`: demean time-series for plotting (preserve raw metrics), lower floor for control-force plotting range, switch learning-curve plot to use `cost_history`, and move `maybe_refresh_docs()` to run after plots/metrics are saved.
- `src/pendulum_sim/rl_env.py`: make episode initial state random (unless `initial_state` provided) so no-noise regulation rollouts are in-distribution for training.
- `src/pendulum_sim/rl_reporting.py` and `tools/tools_refresh_readme.py`: include `cost_initial`/`cost_final` (negative reward) in the JSON summary and surface cost initial/final in the autogenerated README block.

### Testing
- Ran the repository test suite with `pytest` (smoke and unit tests); tests passed without failures.
- Performed a smoke run of the RL pipeline by executing `pendulum_sim.rl_core.main()` to verify plots, metrics files, and `maybe_refresh_docs()` run; plotting and metrics generation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93792695c832aab51e6044553d76b)